### PR TITLE
バリデーション、エラー文の修正

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -10,7 +10,9 @@ class Item < ApplicationRecord
   has_one_attached :image
   has_one :item_transaction
 
-  with_options numericality: { other_than: 1 } do
+  validates :price, numericality: { only_integer: true, message: 'Half-width number' }
+
+  with_options numericality: { other_than: 1, message: 'Select' } do
     validates :category_id
     validates :condition_id
     validates :shipping_charge_id
@@ -26,7 +28,6 @@ class Item < ApplicationRecord
               numericality: {
                 greater_than_or_equal_to: 300,
                 less_than_or_equal_to: 9_999_999,
-                only_integer: true,
                 message: 'Out of setting range'
               }
   end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -32,27 +32,27 @@ RSpec.describe Item, type: :model do
     it 'カテゴリーの情報が必須であること' do
       @item.category_id = 1
       @item.valid?
-      expect(@item.errors.full_messages).to include('Category must be other than 1')
+      expect(@item.errors.full_messages).to include('Category Select')
     end
     it '商品の状態についての情報が必須であること' do
       @item.condition_id = 1
       @item.valid?
-      expect(@item.errors.full_messages).to include('Condition must be other than 1')
+      expect(@item.errors.full_messages).to include('Condition Select')
     end
     it '配送料の負担についての情報が必須であること' do
       @item.shipping_charge_id = 1
       @item.valid?
-      expect(@item.errors.full_messages).to include('Shipping charge must be other than 1')
+      expect(@item.errors.full_messages).to include('Shipping charge Select')
     end
     it '発送元の地域についての情報が必須であること' do
       @item.prefecture_id = 1
       @item.valid?
-      expect(@item.errors.full_messages).to include('Prefecture must be other than 1')
+      expect(@item.errors.full_messages).to include('Prefecture Select')
     end
     it '発送までの日数についての情報が必須であること' do
       @item.days_to_ship_id = 1
       @item.valid?
-      expect(@item.errors.full_messages).to include('Days to ship must be other than 1')
+      expect(@item.errors.full_messages).to include('Days to ship Select')
     end
     it 'price：販売価格の入力が必須であること' do
       @item.price = nil


### PR DESCRIPTION
# what
バリデーション、エラー文の修正

# why
必須機能実装後の最終確認で判明。
エラー文の”half width”が表示されていなかったので、
priceのバリデーションとmessageを修正。
テストコードのメッセージも修正。

https://gyazo.com/1ab21d51c05ceeee73926b94b9364800
テスト結果